### PR TITLE
USB HID Support + Pause/Play

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 4
 
 [[package]]
-name = "adafruit-macropad"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7902bc5085ae127213990ec7d27f5c1c316a303fa35abfeab20a102b6b4449a1"
-dependencies = [
- "cortex-m-rt",
- "rp2040-boot2",
- "rp2040-hal 0.10.2",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,9 +31,9 @@ checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "byteorder"
-version = "1.5.0"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cortex-m"
@@ -156,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "frunk"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,13 +236,14 @@ dependencies = [
 name = "macropad-rp2040"
 version = "0.1.0"
 dependencies = [
- "adafruit-macropad",
  "cortex-m",
  "cortex-m-rt",
  "embedded-hal 1.0.0",
  "panic-halt",
  "rp2040-boot2",
- "rp2040-hal 0.11.0",
+ "rp2040-hal",
+ "usb-device 0.2.9",
+ "usbd-hid",
 ]
 
 [[package]]
@@ -364,35 +360,6 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11e711940087f2cdff8aeae9f4b902e2014c06a00b39a1092686b81ec973d6f"
-dependencies = [
- "bitfield 0.14.0",
- "cortex-m",
- "critical-section",
- "embedded-dma",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "embedded-hal-nb",
- "embedded-io",
- "frunk",
- "fugit",
- "itertools",
- "nb 1.1.0",
- "paste",
- "pio",
- "rand_core",
- "rp2040-hal-macros",
- "rp2040-pac",
- "usb-device",
- "vcell",
- "void",
-]
-
-[[package]]
-name = "rp2040-hal"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb79a4590775204387f334672e6f79c0d734d0a159da23d60677b3c10fa1245"
@@ -417,7 +384,7 @@ dependencies = [
  "rp-hal-common",
  "rp2040-hal-macros",
  "rp2040-pac",
- "usb-device",
+ "usb-device 0.3.2",
  "vcell",
  "void",
 ]
@@ -471,6 +438,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "ssmarshal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e6ad23b128192ed337dfa4f1b8099ced0c2bf30d61e551b65fda5916dbb850"
+dependencies = [
+ "encode_unicode",
+ "serde",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,12 +503,53 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "usb-device"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+
+[[package]]
+name = "usb-device"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
 dependencies = [
  "heapless",
  "portable-atomic",
+]
+
+[[package]]
+name = "usbd-hid"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15e05bf1cfda1e9058cea54fd5b478b11779acf4cf61692a2df4fbb04e6b02a"
+dependencies = [
+ "serde",
+ "ssmarshal",
+ "usb-device 0.2.9",
+ "usbd-hid-macros",
+]
+
+[[package]]
+name = "usbd-hid-descriptors"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ea77bc56883ecb89e728c8d4f2c6d2239240d2e36589acbd867d1ea13c99c"
+dependencies = [
+ "bitfield 0.13.2",
+]
+
+[[package]]
+name = "usbd-hid-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1dce8b4994a6093e268bd97127b957817eb86c7295ccf7a4fcf6be1ab4a0876"
+dependencies = [
+ "byteorder",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
+ "usbd-hid-descriptors",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,10 +41,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
-name = "byteorder"
-version = "1.3.4"
+name = "bitvec"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cortex-m"
@@ -156,12 +168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
 name = "frunk"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +216,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "gcd"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,8 +266,8 @@ dependencies = [
  "panic-halt",
  "rp2040-boot2",
  "rp2040-hal 0.11.0",
- "usb-device 0.2.9",
- "usbd-hid",
+ "usb-device",
+ "usbd-human-interface-device",
 ]
 
 [[package]]
@@ -279,7 +291,17 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive 0.7.4",
+ "rustversion",
 ]
 
 [[package]]
@@ -287,6 +309,44 @@ name = "num_enum_derive"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "option-block"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f2c5d345596a14d7c8b032a68f437955f0059f2eb9a5972371c84f7eef3227"
+
+[[package]]
+name = "packed_struct"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
+dependencies = [
+ "bitvec",
+ "packed_struct_codegen",
+]
+
+[[package]]
+name = "packed_struct_codegen"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -312,7 +372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e09694b50f89f302ed531c1f2a7569f0be5867aee4ab4f8f729bbeec0078e3"
 dependencies = [
  "arrayvec",
- "num_enum",
+ "num_enum 0.5.11",
  "paste",
 ]
 
@@ -339,6 +399,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand_core"
@@ -394,7 +460,7 @@ dependencies = [
  "rand_core",
  "rp2040-hal-macros",
  "rp2040-pac",
- "usb-device 0.3.2",
+ "usb-device",
  "vcell",
  "void",
 ]
@@ -425,7 +491,7 @@ dependencies = [
  "rp-hal-common",
  "rp2040-hal-macros",
  "rp2040-pac",
- "usb-device 0.3.2",
+ "usb-device",
  "vcell",
  "void",
 ]
@@ -464,6 +530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,36 +549,6 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "serde"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "ssmarshal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e6ad23b128192ed337dfa4f1b8099ced0c2bf30d61e551b65fda5916dbb850"
-dependencies = [
- "encode_unicode",
- "serde",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -537,16 +579,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "usb-device"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
 
 [[package]]
 name = "usb-device"
@@ -559,38 +601,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "usbd-hid"
-version = "0.6.2"
+name = "usbd-human-interface-device"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15e05bf1cfda1e9058cea54fd5b478b11779acf4cf61692a2df4fbb04e6b02a"
+checksum = "42ec14dbf3faf02aa63c4a6c10465ccd6b29010380a48e5187d63d5233fbbaf6"
 dependencies = [
- "serde",
- "ssmarshal",
- "usb-device 0.2.9",
- "usbd-hid-macros",
-]
-
-[[package]]
-name = "usbd-hid-descriptors"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2ea77bc56883ecb89e728c8d4f2c6d2239240d2e36589acbd867d1ea13c99c"
-dependencies = [
- "bitfield 0.13.2",
-]
-
-[[package]]
-name = "usbd-hid-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1dce8b4994a6093e268bd97127b957817eb86c7295ccf7a4fcf6be1ab4a0876"
-dependencies = [
- "byteorder",
- "proc-macro2",
- "quote",
- "serde",
- "syn 1.0.109",
- "usbd-hid-descriptors",
+ "frunk",
+ "fugit",
+ "heapless",
+ "num_enum 0.7.4",
+ "option-block",
+ "packed_struct",
+ "usb-device",
 ]
 
 [[package]]
@@ -612,4 +634,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "adafruit-macropad"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7902bc5085ae127213990ec7d27f5c1c316a303fa35abfeab20a102b6b4449a1"
+dependencies = [
+ "cortex-m-rt",
+ "rp2040-boot2",
+ "rp2040-hal 0.10.2",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,12 +247,13 @@ dependencies = [
 name = "macropad-rp2040"
 version = "0.1.0"
 dependencies = [
+ "adafruit-macropad",
  "cortex-m",
  "cortex-m-rt",
  "embedded-hal 1.0.0",
  "panic-halt",
  "rp2040-boot2",
- "rp2040-hal",
+ "rp2040-hal 0.11.0",
  "usb-device 0.2.9",
  "usbd-hid",
 ]
@@ -356,6 +368,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c92f344f63f950ee36cf4080050e4dce850839b9175da38f9d2ffb69b4dbb21"
 dependencies = [
  "crc-any",
+]
+
+[[package]]
+name = "rp2040-hal"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11e711940087f2cdff8aeae9f4b902e2014c06a00b39a1092686b81ec973d6f"
+dependencies = [
+ "bitfield 0.14.0",
+ "cortex-m",
+ "critical-section",
+ "embedded-dma",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-hal-nb",
+ "embedded-io",
+ "frunk",
+ "fugit",
+ "itertools",
+ "nb 1.1.0",
+ "paste",
+ "pio",
+ "rand_core",
+ "rp2040-hal-macros",
+ "rp2040-pac",
+ "usb-device 0.3.2",
+ "vcell",
+ "void",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ adafruit-macropad = "*"
 #ws2812-pio = "0.3.0"
 
 #USB HID
-usbd-hid = "0.6"
-usb-device = "0.2"
+usbd-human-interface-device = "0.6.0"
+usb-device = "0.3"
 
 # Abort on panic instead of trying to "unwind"
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rp2040-boot2 = "0.3"  # RP2040 bootloader
 embedded-hal = { version = "1.0.0" }  # Hardware Abstraction Layer (HAL) for General Embedded Systems
 
 #BSP
-#adafruit-macropad = "*"
+adafruit-macropad = "*"
 #ws2812-pio = "0.3.0"
 
 #USB HID

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,20 @@ edition = "2024"
 [dependencies]
 panic-halt = "0.2"
 cortex-m-rt = "0.7" # Runtime for ARM Cortex-M
+cortex-m = "0.7"  # ARM Cortex-M stuff
+
+#Hardware Access
 rp2040-hal = { version="0.11", features=["rt", "critical-section-impl"] } # Hardware Abstraction Layer (HAL) for RP2040
 rp2040-boot2 = "0.3"  # RP2040 bootloader
 embedded-hal = { version = "1.0.0" }  # Hardware Abstraction Layer (HAL) for General Embedded Systems
-cortex-m = "0.7"  # ARM Cortex-M stuff
-adafruit-macropad = "*"
+
+#BSP
+#adafruit-macropad = "*"
 #ws2812-pio = "0.3.0"
+
+#USB HID
+usbd-hid = "0.6"
+usb-device = "0.2"
 
 # Abort on panic instead of trying to "unwind"
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -23,26 +23,27 @@ cargo run --release
 
 ### Rotary Encoder
 
-- Encoder: Volume Control
-- Switch: Toggle between brightness modes
+- Encoder: Volume Control [not implemented]
+- Switch: Toggle between brightness modes [not implemented]
 
 ### Keys
 
-0. Discord Mute (Custom keybind, bug with discord repeating keys)
-1. Pause/Play
-2. Skip Track
-3. Screenshot Entire Screen(s) - Command + Shift + 3
-4. Screenshot Selection of Screen - Command + Shift + 4
+0. Discord Mute (Custom keybind, bug with discord repeating keys) [not implemented]
+1. Pause/Play [not implemented]
+2. Skip Track [not implemented]
+3. Screenshot Entire Screen(s) - Command + Shift + 3 [not implemented]
+4. Screenshot Selection of Screen - Command + Shift + 4 [not implemented]
 
 ## TODO (no order)
 
 - [ ] Reintroduce previous features
 - [ ] Clean up project
 - [ ] Use Enums or Trait Objects
+- [ ] Figure out useful keys
 
-## Bugs
+## Notes & Bugs
 
-- later issue
+- usbd_hid crate was giving me issues with keyboard input not being recognized, used usbd-human-interface-device instead
 
 # Resources
 
@@ -52,3 +53,4 @@ cargo run --release
 - [RP2040 HAL Template (pins are different used for setup)](https://github.com/rp-rs/rp2040-project-template)
 - [Adafruit Macropad BSP](https://lib.rs/crates/adafruit-macropad)
 - [BSP LED Blink Example](https://github.com/rp-rs/rp-hal-boards/blob/56e044061073fb49aef93984b629af5c5bc1a11c/boards/adafruit-macropad/examples/adafruit-macropad_blinky.rs)
+- [usbd-human-interface-device](https://docs.rs/usbd-human-interface-device/)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ cargo run --release
 
 - [ ] Reintroduce previous features
 - [ ] Clean up project
+- [ ] Use Enums or Trait Objects
 
 ## Bugs
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cargo run --release
 ### Keys
 
 0. Discord Mute (Custom keybind, bug with discord repeating keys) [not implemented]
-1. Pause/Play [not implemented]
+1. Pause/Play [implemented]
 2. Skip Track [not implemented]
 3. Screenshot Entire Screen(s) - Command + Shift + 3 [not implemented]
 4. Screenshot Selection of Screen - Command + Shift + 4 [not implemented]

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,15 +63,30 @@ fn main() -> ! {
     // Configure the built-in LED pin as output
     let mut led_pin = pins.led.into_push_pull_output();
 
-    // Configure key 1 as input
+    // Configure first 6 keys as input
     let mut key1 = pins.key1.into_pull_up_input();
+    let mut key2 = pins.key2.into_pull_up_input();
+    let mut key3 = pins.key3.into_pull_up_input();
+    let mut key4 = pins.key4.into_pull_up_input();
+    let mut key5 = pins.key5.into_pull_up_input();
+    let mut key6 = pins.key6.into_pull_up_input();
 
-    // Turns on the LED pin when first key is pressed
+    // Turns on the LED pin when key is pressed
     loop {
         if key1.is_low().unwrap() { //Check if key1 is pressed (low state)
             led_pin.set_high().unwrap(); //Turn on LED
-        } 
-        else {  //Do opposite if key1 is not pressed
+        }  else if key2.is_low().unwrap() {
+            led_pin.set_high().unwrap();
+        } else if key3.is_low().unwrap() {
+            led_pin.set_high().unwrap();
+        } else if key4.is_low().unwrap() {
+            led_pin.set_high().unwrap();
+        } else if key5.is_low().unwrap() {
+            led_pin.set_high().unwrap();
+        } else if key6.is_low().unwrap() {
+            led_pin.set_high().unwrap();
+        }
+        else {  //Do opposite if key 1-6 is not pressed
             led_pin.set_low().unwrap();
         }
         delay.delay_ms(10);


### PR DESCRIPTION
- Adds USB Support and HID Interface
- Adds Pause/Play on key2
- Adds "a" key on key1 for now

---

This pull request adds initial USB HID (Human Interface Device) support to the Adafruit Macropad firmware, enabling basic keyboard and media key functionality over USB. It updates dependencies, improves documentation, and implements the first two keys (sending 'A' and Play/Pause) as working examples. The code now sets up all 12 keys as inputs and integrates the `usbd-human-interface-device` crate for HID support.

**USB HID Integration and Key Handling:**

* Added `usbd-human-interface-device` and `usb-device` dependencies to `Cargo.toml` to enable USB HID functionality.
* In `src/main.rs`, imported necessary USB HID modules and set up the USB bus and HID class, supporting both keyboard and media control reports. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL14-R30) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL66-R148)
* Configured all 12 Macropad keys as inputs; implemented logic to send an 'A' key press when key 1 is pressed and Play/Pause media control when key 2 is pressed, using the new HID interface.

**Documentation Updates:**

* Updated `README.md` to clarify which keys and features are implemented or not, and added notes about the switch to `usbd-human-interface-device` due to previous issues with `usbd_hid`.
* Added a link to the `usbd-human-interface-device` documentation in the resources section of the `README.md`.