### PR TITLE
Adds Reject, Unflagged, & Pick Lightroom Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ cargo run --release
 
 1. A
 2. Pause/Play
-3. 
-4. 
-5. 
-6. 
-7. 
-8. 
-9. 
-10. 
-11. 
-12. 
+3. Skip
+4. Reject (lightroom)
+5. Unflagged (lightroom)
+6. Pick (lightroom)
+7.
+8.
+9.
+10.
+11.
+12.
 
 ## TODO (no order)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,17 @@ fn main() -> ! {
             hid.device::<ConsumerControl<_>, _>().write_report(&MultipleConsumerReport {
                 codes: [Consumer::ScanNextTrack, Consumer::Unassigned, Consumer::Unassigned, Consumer::Unassigned]
             }).ok(); //skip
+        }
+        //lightroom commands 
+        else if key4_pressed {
+            led_pin.set_high().unwrap();
+            hid.device::<NKROBootKeyboard<_>, _>().write_report([Keyboard::X]).ok(); // X, reject
+        } else if key5_pressed {
+            led_pin.set_high().unwrap();
+            hid.device::<NKROBootKeyboard<_>, _>().write_report([Keyboard::U]).ok(); // U, unflagged
+        } else if key6_pressed {
+            led_pin.set_high().unwrap();
+            hid.device::<NKROBootKeyboard<_>, _>().write_report([Keyboard::P]).ok(); // P, pick
         } else {
             //No key pressed or released, turn off LED, release keys and media controls
             led_pin.set_low().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,15 @@ fn main() -> ! {
         let key1_pressed = key1.is_low().unwrap();
         let key2_pressed = key2.is_low().unwrap();
         let key3_pressed = key3.is_low().unwrap();
+        let key4_pressed = key4.is_low().unwrap();
+        let key5_pressed = key5.is_low().unwrap();
+        let key6_pressed = key6.is_low().unwrap();
+        let key7_pressed = key7.is_low().unwrap();
+        let key8_pressed = key8.is_low().unwrap();
+        let key9_pressed = key9.is_low().unwrap();
+        let key10_pressed = key10.is_low().unwrap();
+        let key11_pressed = key11.is_low().unwrap();
+        let key12_pressed = key12.is_low().unwrap();
 
         // key pressed?
         if key1_pressed {
@@ -140,7 +149,6 @@ fn main() -> ! {
             hid.device::<ConsumerControl<_>, _>().write_report(&MultipleConsumerReport {
                 codes: [Consumer::ScanNextTrack, Consumer::Unassigned, Consumer::Unassigned, Consumer::Unassigned]
             }).ok(); //skip
-
         } else {
             //No key pressed or released, turn off LED, release keys and media controls
             led_pin.set_low().unwrap();


### PR DESCRIPTION
This pull request adds new Lightroom command support to both the documentation and the firmware, allowing keys to trigger "Reject", "Unflagged", and "Pick" actions. It also expands the firmware to read more key inputs, preparing for additional features or key mappings.

**Lightroom command support:**

* Updated the `README.md` to document new key actions: Skip, Reject (Lightroom), Unflagged (Lightroom), and Pick (Lightroom).
* Added firmware logic to handle keys 4, 5, and 6, sending the appropriate keyboard reports for Lightroom commands (X for Reject, U for Unflagged, P for Pick).

**Key input expansion:**

* Added logic to read the state of keys 4 through 12, enabling future support for more key actions.